### PR TITLE
removing third parameter in round() method calls as it's not supported by php <5.3

### DIFF
--- a/author.php
+++ b/author.php
@@ -129,7 +129,7 @@ get_header(); ?>
           </span>
           <span class="post-readtime small-light-text">
             <span class="glyphicon glyphicon-time"></span>
-            <?php echo round(wcount() / 250, 0, PHP_ROUND_HALF_UP); ?> minute read
+            <?php echo round(wcount() / 250, 0); ?> minute read
           </span> 
         </div>
         <div class="post-entry">

--- a/category.php
+++ b/category.php
@@ -105,7 +105,7 @@ get_header(); ?>
           </span>
           <span class="post-readtime small-light-text">
             <span class="glyphicon glyphicon-time"></span>
-            <?php echo round(wcount() / 250, 0, PHP_ROUND_HALF_UP); ?> minute read
+            <?php echo round(wcount() / 250, 0); ?> minute read
           </span> 
         </div>
         <div class="post-entry">

--- a/index.php
+++ b/index.php
@@ -86,7 +86,7 @@ get_header(); ?>
               </span>
               <span class="post-readtime small-light-text">
                 <!--<span class="glyphicon glyphicon-time"></span>-->
-                <?php echo round(wcount() / 250, 0, PHP_ROUND_HALF_UP); ?> minute read
+                <?php echo round(wcount() / 250, 0); ?> minute read
               </span> 
             </div>
 
@@ -149,7 +149,7 @@ get_header(); ?>
               </span>
               <span class="post-readtime small-light-text">
                 <span class="glyphicon glyphicon-time"></span>
-                <?php echo round(wcount() / 250, 0, PHP_ROUND_HALF_UP); ?> minute read
+                <?php echo round(wcount() / 250, 0); ?> minute read
               </span> 
             </div>
             <div class="post-entry">

--- a/partials/featured-section.php
+++ b/partials/featured-section.php
@@ -23,7 +23,7 @@
             <?php the_time('F jS, Y') ?>
           </span>
           <span class="post-readtime small-light-text">
-            <?php echo round(wcount() / 250, 0, PHP_ROUND_HALF_UP); ?> minute read
+            <?php echo round(wcount() / 250, 0); ?> minute read
           </span> 
         </div>
         <div class="post-entry">

--- a/single.php
+++ b/single.php
@@ -38,7 +38,7 @@ get_header(); ?>
           </span>
           <span class="post-readtime small-light-text">
             <span class="glyphicon glyphicon-time"></span>
-            <?php echo round(wcount() / 250, 0, PHP_ROUND_HALF_UP); ?> minute read
+            <?php echo round(wcount() / 250, 0); ?> minute read
           </span> 
         </div>
         <div class="post-entry">

--- a/tag.php
+++ b/tag.php
@@ -83,7 +83,7 @@ get_header(); ?>
           </span>
           <span class="post-readtime small-light-text">
             <span class="glyphicon glyphicon-time"></span>
-            <?php echo round(wcount() / 250, 0, PHP_ROUND_HALF_UP); ?> minute read
+            <?php echo round(wcount() / 250, 0); ?> minute read
           </span> 
         </div>
         <div class="post-entry">


### PR DESCRIPTION
Hi,

First of all I love the theme!

But unfortunately my cheap shared hosting only runs PHP 5.2.17, and was throwing errors on the round calls you make when you're calculating how long posts will take to read.

I've gone through and removed the third parameter form all the round() calls and tested it on my server which is running PHP 5.2.17 and everything looks sweet.

I figured I'm probably not the only person who might have an slightly older version of PHP, so thought I'd push the changes and create my first ever pull request.

Cheers.

Jolyon
